### PR TITLE
Addde missing include of OneSheeld header

### DIFF
--- a/examples/Advanced/ToggleButton/ToggleButton.ino
+++ b/examples/Advanced/ToggleButton/ToggleButton.ino
@@ -19,6 +19,7 @@ defining CUSTOM_SETTINGS and the shields respective INCLUDE_ define.
 
 */
 
+#include <OneSheeld.h>
 
 /* Seven segment pins. */
 int segmentA = 2;


### PR DESCRIPTION
This example missed the `#include <OneSheeld.h>` statement but uses the `OneSheeld.delay();` function so the library must be included.